### PR TITLE
Update fetch_seqs.sh

### DIFF
--- a/fetch_seqs.sh
+++ b/fetch_seqs.sh
@@ -5,7 +5,7 @@ getseq() {
 	n=$1
 	acn=${n##*_}
 	echo $1 > data/dbseqs/${acn}.fasta
-	curl "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${acn}&rettype=fasta" >> data/dbseqs/${acn}.fasta
+	curl "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&amp;id=${acn}&amp;rettype=fasta" >> data/dbseqs/${acn}.fasta
 }
 export -f getseq
 rm -rf data/dbseqs; mkdir data/dbseqs


### PR DESCRIPTION
updated url for NCBI eutils seq fetch

This allows seqs to be fetched with no errors, but then will duplicate the accession number 
e.g., 
>D109_AB097465
>AB097465.1 Symbiodinium sp. HPiH-2 genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2, 24S 